### PR TITLE
Fix deserialization of MetricValue counts

### DIFF
--- a/services/preview/monitor/mgmt/2018-03-01/insights/models.go
+++ b/services/preview/monitor/mgmt/2018-03-01/insights/models.go
@@ -4261,7 +4261,7 @@ type MetricValue struct {
 	// Total - the sum of all of the values in the time range.
 	Total *float64 `json:"total,omitempty"`
 	// Count - the number of samples in the time range. Can be used to determine the number of values that contributed to the average value.
-	Count *int64 `json:"count,omitempty"`
+	Count *float64 `json:"count,omitempty"`
 }
 
 // BasicMultiMetricCriteria the types of conditions for a multi resource alert.


### PR DESCRIPTION
Counts are returned from the API in a format like `1.0`, which cannot be deserialized into an `int64` (see https://github.com/Azure/azure-rest-api-specs/issues/5130).

As this is generated code, this is a temporary workaround until the above issue is fixed.
